### PR TITLE
changed .truncate() to .del() in users table migration

### DIFF
--- a/data/seeds/002-users.js
+++ b/data/seeds/002-users.js
@@ -19,7 +19,7 @@ exports.seed = async function(knex, Promise) {
   // await knex("users").insert(fakeUsers);
 
   return knex("users")
-    .truncate()
+    .del()
     .then(function() {
       // Inserts seed entries
       return knex("users").insert([


### PR DESCRIPTION
apparently you can't have truncate in a table that is referenced as a foreign key